### PR TITLE
Update Nightingale.yml

### DIFF
--- a/recipes/meta/Nightingale.yml
+++ b/recipes/meta/Nightingale.yml
@@ -12,6 +12,7 @@ ingredients:
     - djcj/nightingale
 
 script:
+  - if [ -e usr/share/glib-2.0/schemas/ ] && [ "x$(which glib-compile-schemas)" != "x" ] ; then sudo apt-get install -y libglib2.0-bin ; fi
   - rm -rf usr/lib/x86_64-linux-gnu/x264-10bit/ usr/bin/nightingale
   - cat <<\EOF> usr/bin/nightingale
   - #!/bin/sh

--- a/recipes/meta/Nightingale.yml
+++ b/recipes/meta/Nightingale.yml
@@ -12,7 +12,6 @@ ingredients:
     - djcj/nightingale
 
 script:
-  - sudo apt-get install -y libglib2.0-bin
   - rm -rf usr/lib/x86_64-linux-gnu/x264-10bit/ usr/bin/nightingale
   - cat <<\EOF> usr/bin/nightingale
   - #!/bin/sh


### PR DESCRIPTION
The Recipe script requires glib-compile-schemas which is part of libglib2.0-bin. But when I think about it, it shouldn't be installed directly on the build system through the YAML script but instead be treated as a regular build dependency, like wget and fuse.