### PR TITLE
fix find command error

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -95,7 +95,7 @@ get_apprun()
 copy_deps()
 {
   PWD=$(readlink -f .)
-  FILES=$(find . -type f -executable -or -name *.so.* -or -name *.so | sort | uniq )
+  FILES=$(find . -type f -executable -or -name "*.so.*" -or -name "*.so" | sort | uniq )
   for FILE in $FILES ; do
     ldd "${FILE}" | grep "=>" | awk '{print $3}' | xargs -I '{}' echo '{}' >> DEPSFILE
   done


### PR DESCRIPTION
on debian10 chroot
after execute . ./functions.sh and input copy_dep, it will return an error
```
find: paths must precede expression: `libCollada.so'
find: possible unquoted pattern after predicate `-name'?
```
so I added a couple of quotation marks to fix this error