### PR TITLE
Update intef-exe.yml: add 3 python packages

### DIFF
--- a/recipes/intef-exe.yml
+++ b/recipes/intef-exe.yml
@@ -4,6 +4,9 @@ binpatch: true
 ingredients:
   packages:
     - intef-exe
+    - python-cffi-backend
+    - python-minimal
+    - python-zope.interface
   dist: oldstable
   sources:
     - deb http://ftp.debian.org/debian/ oldstable main


### PR DESCRIPTION
Packages python-cffi-backend, python-minimal and python-zope.interface are dependencies no longer processed by pkg2appimage since 8/24/2020, see issue #435. Add these 3 packages to the recipe to make it work again.