### PR TITLE
Fix: MongoDB Compass Community not building

### DIFF
--- a/recipes/MongoDB_Compass_Community.yml
+++ b/recipes/MongoDB_Compass_Community.yml
@@ -2,13 +2,11 @@ app: MongoDB_Compass_Community
 lowerapp: mongodb-compass-community
 
 ingredients:
-  dist: trusty
-  sources:
-    - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   script:
-    - DEB=$(wget -q "https://www.mongodb.com/download-center/compass?jmp=docs" -O - | sed -e 's|,|,\n|g' | grep -e "https://downloads.mongodb.com/compass/.*mongodb-.*_amd64.deb" | cut -d '"' -f 4 | grep community | head -n 1)
-    - wget -c "$DEB"
-    - ls mongo*.deb | cut -d _ -f 2 | sed -e 's|.deb||g' > VERSION
+    - DLD=$(wget -q "https://api.github.com/repos/mongodb-js/compass/releases/latest"  -O - | grep -E "https.*amd64.deb" | cut -d'"' -f4  | sed '$!d')
+    - wget -c $DLD
+    - echo $DLD | cut -d/ -f8 > VERSION
 
 script:
-  - ls
+  - cp usr/share/applications/mongodb-compass.desktop .
+  - cp usr/share/pixmaps/mongodb-compass.png .


### PR DESCRIPTION
The current recipes try to get latest version from dead link and failed, fixing it by changing fetching from MongoDB Compass [github release](https://github.com/mongodb-js/compass/releases) instead.
