### PR TITLE
Use ubuntu 18.04 for to create the appimage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,17 @@ env:
 jobs:
   build:
     runs-on: ubuntu-20.04
-
+    container:
+      image: ubuntu:18.04
+      options: --privileged
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libarchive-tools curl zsync squashfs-tools aria2 desktop-file-utils
+        apt-get update
+        apt-get install -y sudo libarchive-tools curl zsync squashfs-tools aria2 desktop-file-utils wget fuse binutils file
 
     - name: Build and Release
       run: |


### PR DESCRIPTION
This enables using pkg2appimage within builds
based on ubuntu-18.04 (bionic) which is for example used by vscodium

Fixes #544 