### PR TITLE
Fix appimagetool usage in docker

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -226,7 +226,7 @@ generate_type2_appimage()
   fi
   if [ "$DOCKER_BUILD" ]; then
     appimagetool_tempdir=$(mktemp -d)
-    mv appimagetool "$appimagetool_tempdir"
+    mv "$appimagetool" "$appimagetool_tempdir"
     pushd "$appimagetool_tempdir" &>/dev/null
     ls -al
     ./appimagetool --appimage-extract


### PR DESCRIPTION
Invocation from docker was failing because the `generate_type2_appimage` function was attempting to operate on a local path `appimagetool` instead of expanding the `$appimagetool` variable, giving this error:
```
mv: cannot stat 'appimagetool': No such file or directory
```

Adding this line to my script fixed my job:
```sh
sed -i -e 's/mv appimagetool/mv $appimagetool/' /opt/pkg2appimage.AppDir/usr/share/pkg2appimage/functions.sh
```

Full CI script: https://gitlab.com/cajomar/snowballz/-/blob/59fc8c35168a007a064e63885425a47278bbb989/.gitlab-ci.yml