### PR TITLE
Fixed correct handling of OBS repositories as debian source

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -384,7 +384,7 @@ function apt-get.update(){
     local base_url=${repo_info[1]}
     local dist_name=${repo_info[2]}
 
-    # detect opensuze build service repositories, which are listed using a single / at the end (according to pkg2appimage documentation)
+    # Detect openSUSE Build Service (OBS) repositories, which are listed using a single / at the end (according to pkg2appimage documentation)
     if test "${dist_name}" = "/" ; then
       echo "Caching ${base_url} ${dist_name}..."
       local repo_url="${base_url}/Packages.gz"


### PR DESCRIPTION
Took me a while to find this, but according to the pkg2appimage documentation, Debian repositories from the opensuse build system should be listed as:

dist: [ubuntu distrib]
sources:
  - deb https://download.opensuse.org/repositories/[...]:/[software name]/[ubuntu distrib]/ /

...but in functions.sh, the parsing method employed in apt-get.update() is only compatible with the classical syntax such as 
  - deb http://archive.ubuntu.com/ubuntu/ [ubuntu distrib] main universe

...so it fails and doesn't fill the Packages.gz file.
The present patch solves this (probably not very elegantly).