### PR TITLE
add libpam.so.0 and libpam_misc.so.0 to exclude list

### DIFF
--- a/excludelist
+++ b/excludelist
@@ -239,3 +239,7 @@ libfribidi.so.0 # https://github.com/olive-editor/olive/issues/221 and https://g
 # https://github.com/ONLYOFFICE/appimage-desktopeditors/issues/3
 # Apparently coreutils depends on it, so it should be safe to assume that it comes with every target system
 libgmp.so.10
+
+# PAM libraries are distro specific and should not be bundled even though they share a large part of public API
+libpam.so.0
+libpam_misc.so.0


### PR DESCRIPTION
Pam libraries are system specific, when using bundled PAM libs from e.g. fedora on Debian you can get an error such as `Authentication failed: Module is unkown`. Using system PAM libraries works completely fine, also If the system doesn't have PAM libraries I do not think PAM works at all, so there should not be any reason to bundle them.