### PR TITLE
Add libwayland-client.so.0 to exclude list

### DIFF
--- a/excludelist
+++ b/excludelist
@@ -87,6 +87,10 @@ libX11-xcb.so.1
 # https://github.com/probonopd/linuxdeployqt/issues/582
 # Uncertain if this is required to be bundled for some distributions - if so, please let us know
 
+libwayland-client.so.0
+# https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316
+# New version of Mesa has some dependency issues with libwayland-client if it is bundled
+
 # --- Bundling GLib and its consequences ---
 # The following libraries need to be privately bundled, otherwise this error can happen:
 # - <AppDir>/usr/lib/x86_64-linux-gnu/libgnutls.so.30: version `GNUTLS_3_6_9' not found (required by /lib64/libglib-2.0.so.0)

--- a/excludelist
+++ b/excludelist
@@ -88,6 +88,7 @@ libX11-xcb.so.1
 # Uncertain if this is required to be bundled for some distributions - if so, please let us know
 
 libwayland-client.so.0
+# https://github.com/AppImageCommunity/pkg2appimage/pull/559
 # https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316
 # New version of Mesa has some dependency issues with libwayland-client if it is bundled
 


### PR DESCRIPTION
I have noticed that my Qt6 AppImage is failing on new distros such as Fedora 40, Arch etc. 
It turns out an EGL/GLX integration is running into some issues, upon further inspection I found out about this issue here https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316 
After removing libwayland-client.so.0 from AppImage all issues were suddenly resolved